### PR TITLE
Void Bag: Add NBT check to model predicate, serialize a preview-stack with component.

### DIFF
--- a/src/main/java/dev/sweetberry/wwizardry/client/WanderingClient.java
+++ b/src/main/java/dev/sweetberry/wwizardry/client/WanderingClient.java
@@ -102,6 +102,8 @@ public class WanderingClient implements ClientModInitializer {
 			var client = MinecraftClient.getInstance();
 			if (client.player == null)
 				return 0.0f;
+			var nbt = itemStack.getNbt();
+			if (nbt != null && nbt.contains("Locked")) return nbt.getBoolean("Locked") ? 1.0f : 0.0f;
 			var bag = VoidBagComponent.getForPlayer(client.player);
 			return bag.locked ? 1.0f : 0.0f;
 		}));

--- a/src/main/java/dev/sweetberry/wwizardry/component/VoidBagComponent.java
+++ b/src/main/java/dev/sweetberry/wwizardry/component/VoidBagComponent.java
@@ -2,6 +2,7 @@ package dev.sweetberry.wwizardry.component;
 
 import dev.onyxstudios.cca.api.v3.component.sync.AutoSyncedComponent;
 import dev.onyxstudios.cca.api.v3.entity.PlayerComponent;
+import dev.sweetberry.wwizardry.item.VoidBagItem;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.Inventories;
 import net.minecraft.inventory.Inventory;
@@ -39,6 +40,11 @@ public class VoidBagComponent implements Inventory, PlayerComponent<VoidBagCompo
 	public void writeToNbt(NbtCompound tag) {
 		Inventories.writeNbt(tag, inventory);
 		tag.putBoolean("Locked", locked);
+		ItemStack previewStack = VoidBagItem.INSTANCE.getDefaultStack();
+		previewStack.getOrCreateNbt().putBoolean("Locked", locked);
+		NbtCompound previewCompound = new NbtCompound();
+		previewStack.writeNbt(previewCompound);
+		tag.put("PreviewStack", previewCompound);
 	}
 
 	@Override


### PR DESCRIPTION
Allows bags to have an NBT boolean `Locked` that affects the model predicate.
Serializes a void bag stack with this NBT alongisde each void bag component.

This allows for two things:
 - One, it allows visibly locked and unlocked bags to be put in display cases (e.g. locked glowcase blocks) for convention tutorials via NBT.
 - Two, it allows switchy to show whether a component is locked or unlocked visually via data.